### PR TITLE
fix: add pretty good search threshold

### DIFF
--- a/backend/src/lib/hybrid-search.ts
+++ b/backend/src/lib/hybrid-search.ts
@@ -5,8 +5,7 @@ import { getPresignedUrl } from "./presign";
 
 const NAMESPACE = "searchable-whole-earth-page";
 
-const vec_threshold = 0.3; // thresholds need tested
-const bm25_threshold = 0.7;
+const vec_threshold = 0.3;
 
 export type TurbopufferNamespace = ReturnType<Turbopuffer["namespace"]>;
 export type Bm25Promise = Promise<Awaited<ReturnType<TurbopufferNamespace["query"]>>>;
@@ -100,7 +99,9 @@ export async function hybridSearch(
 				r2_object_id: rowData.r2_object_id,
 			},
 		};
-	}).filter((i) => i.score <= vec_threshold);
+	});
+
+	const thresholdVecResults = vectorResults.filter((i) => i.score <= vec_threshold);
 
 	const bm25Results = (bm25Response.rows ?? []).map((row) => {
 		const rowData = row as Record<string, unknown>;
@@ -114,9 +115,13 @@ export async function hybridSearch(
 				r2_object_id: rowData.r2_object_id,
 			},
 		};
-	}).filter((i) => i.score >= bm25_threshold);
+	});
 
-	const fused = reciprocalRankFusion(vectorResults, bm25Results);
+	if (bm25Results.length === 0) {
+		return [];
+	}
+
+	const fused = reciprocalRankFusion(thresholdVecResults, bm25Results);
 	const topResults = fused.slice(0, matchCount);
 
 	const urlStart = performance.now();

--- a/backend/src/lib/hybrid-search.ts
+++ b/backend/src/lib/hybrid-search.ts
@@ -5,6 +5,9 @@ import { getPresignedUrl } from "./presign";
 
 const NAMESPACE = "searchable-whole-earth-page";
 
+const vec_threshold = 0.3; // thresholds need tested
+const bm25_threshold = 0.7;
+
 export type TurbopufferNamespace = ReturnType<Turbopuffer["namespace"]>;
 export type Bm25Promise = Promise<Awaited<ReturnType<TurbopufferNamespace["query"]>>>;
 
@@ -97,7 +100,7 @@ export async function hybridSearch(
 				r2_object_id: rowData.r2_object_id,
 			},
 		};
-	});
+	}).filter((i) => i.score <= vec_threshold);
 
 	const bm25Results = (bm25Response.rows ?? []).map((row) => {
 		const rowData = row as Record<string, unknown>;
@@ -111,7 +114,7 @@ export async function hybridSearch(
 				r2_object_id: rowData.r2_object_id,
 			},
 		};
-	});
+	}).filter((i) => i.score >= bm25_threshold);
 
 	const fused = reciprocalRankFusion(vectorResults, bm25Results);
 	const topResults = fused.slice(0, matchCount);


### PR DESCRIPTION
### Description

Search always returned 30 results, even for nonsense queries. This PR adds a threshold for vectorResults, preventing search terms like "xyzabcxyz" from returning results. Does not add threshold for bm25Results because this promoted unwanted behavior, e.g., "California" returns 0, "Fuller" returns 0, despite "Buckminster Fuller" returning 30 results. Instead, when `(bm25Results.length === 0)`, we `return []`.

### Some Tests w/ Threshold

**California**
```
(log)   Query: "California"
  (log) [test] vec scores:  [
  0.30346626, 0.33691782, 0.34290928,
  0.34435958, 0.34458983,  0.3469044,
  0.34726137, 0.35452485, 0.35469562,
   0.3547305, 0.35483706, 0.35511345,
    0.357172, 0.35946244, 0.36046958,
   0.3626154, 0.36332518, 0.36672664,
   0.3678742, 0.36812156, 0.36927575,
  0.36955726,  0.3705151, 0.37142503,
  0.37155098,  0.3717391,  0.3722613,
  0.37277794, 0.37334687,  0.3738836
]
  (log) [test] bm25 scores:  [
  3.7995183, 3.7937412, 3.7937412,
  3.7879639, 3.7764094, 3.7744837,
  3.7648547,  3.762929, 3.7610033,
  3.7590775, 3.7513745, 3.7455971,
    3.73982, 3.7378943, 3.7340426,
   3.732117, 3.7263396, 3.7263396,
  3.7263396, 3.7244139, 3.7205625,
  3.7205625, 3.7186365, 3.7186365,
  3.7167108,  3.714785, 3.7109337,
  3.7109337, 3.7090077,  3.707082
]
  (log)   Found 30 results
```

**Nonsense**
```
(log)   Query: "jjoejfojefj"
  (log) [test] vec scores:  [
  0.31171215, 0.33746594,  0.3383541,
  0.33918238, 0.34167325,  0.3420881,
  0.34273016, 0.34375703,   0.345142,
  0.34712297,  0.3478061,  0.3491041,
  0.34969997, 0.35055953, 0.35159796,
   0.3523351, 0.35253453, 0.35389018,
  0.35469353, 0.35517365, 0.35616755,
   0.3568496, 0.35687608,  0.3582493,
  0.35924459, 0.36178565, 0.36225653,
   0.3628772, 0.36298716, 0.36389136
]
  (log) [test] bm25 scores:  []
  (log)   Found 0 results
```

**Buckminster Fuller**
```
(log)   Query: "Buckminster Fuller"
  (log) [test] vec scores:  [
  0.23021281, 0.23409587, 0.23749816,
  0.25132293, 0.25866985,  0.2606092,
  0.26363772, 0.26417744, 0.26452655,
   0.2676012,  0.2696182, 0.27098358,
  0.27188534, 0.27312976, 0.27315104,
  0.27328426, 0.27505612,  0.2751348,
  0.27820492, 0.27905166,  0.2819633,
  0.28324372, 0.28488398, 0.29617292,
  0.29632556, 0.29727954, 0.30308223,
   0.3086121, 0.30976993, 0.31911486
]
  (log) [test] bm25 scores:  [
  18.009584, 16.853603,   16.57018,
  16.442131, 16.194468,  16.178982,
  16.035976, 15.909866,  15.900447,
  15.729187,  15.52557,  15.504288,
  15.490845, 15.416203,  15.398238,
  15.135776, 15.032564,  15.025302,
  14.758575, 14.733107, 14.5410595,
   14.50476, 14.419992,  14.335043,
  14.234923, 14.169332,  14.146851,
  14.071501,  13.73674,  13.666498
]
  (log)   Found 30 results
```

**Fuller**
```
(log)   Query: "Fuller"
  (log) [test] vec scores:  [
   0.3162254, 0.32730764, 0.32870477,
   0.3351615,  0.3436631,  0.3441134,
   0.3451764, 0.34617394, 0.35008448,
   0.3515789,  0.3530594, 0.35749483,
  0.36173105, 0.36501485,   0.366468,
   0.3676632, 0.37026858, 0.37095916,
  0.37431514, 0.37550402, 0.37660974,
  0.37826872,   0.379848, 0.38158017,
   0.3818977,  0.3825122, 0.38451678,
  0.38522506, 0.38555074, 0.38909703
]
  (log) [test] bm25 scores:  [
   8.199767,  7.932522,  7.890102,
  7.7840524, 7.7076964,  7.678003,
  7.6737604, 7.6695185, 7.6652765,
   7.491355,  7.471372, 7.4234834,
   7.398031, 7.3174334, 7.2538037,
   7.249562,  7.211384,  7.211384,
  7.1791334,  7.177448,  7.147909,
  7.1138177,  7.084124,  7.080555,
  7.0580134,  7.028978,  7.024736,
   7.003526,  7.003526, 6.9992843
]
  (log)   Found 30 results
```

**Wittgenstein**
```
(log)   Query: "Wittgenstein"
  (log) [test] vec scores:  [
   0.3255092, 0.33702224, 0.33871287,
  0.34167266, 0.34349543,  0.3484763,
   0.3485371,  0.3490671, 0.34957933,
  0.35011774, 0.35150498, 0.35214055,
  0.35383773, 0.35402983, 0.35466272,
   0.3547576, 0.35620463, 0.35661805,
  0.35723722, 0.35735804, 0.35737097,
  0.35798353,  0.3579985,   0.358073,
  0.35853392, 0.35859573,  0.3587913,
   0.3590846, 0.35973984, 0.36005992
]
  (log) [test] bm25 scores:  [
  10.292732,  9.580512,
   9.099738,  8.350943,
   7.320875,  7.268427,
    7.22035, 7.1479397,
   6.910032, 4.8203945,
  4.5157456, 4.4873857,
  4.4873857,  4.422577
]
  (log)   Found 14 results
```